### PR TITLE
SDMOB-276 migrate ios to s3 transfer utility

### DIFF
--- a/android/src/main/kotlin/com/famproperties/amazon_s3_cognito/AwsRegionHelper.kt
+++ b/android/src/main/kotlin/com/famproperties/amazon_s3_cognito/AwsRegionHelper.kt
@@ -39,7 +39,7 @@ class AwsRegionHelper(private val context: Context, private val onUploadComplete
         val s3RegionName = s3Map.get("Region") as String
 
         bucketName = s3Map.get("Bucket") as String
-        bucketUrl = "https://s3-$s3RegionName.amazonaws.com/$bucketName"
+        bucketUrl = "https://$bucketName.s3.amazonaws.com"
         amazonS3Client = AmazonS3Client(credentialsProvider, Region.getRegion(s3RegionName))
 
         // skip md5 integrity check, which always fails despite successful image uploads

--- a/example/android/app/src/main/res/raw/awsconfiguration.json
+++ b/example/android/app/src/main/res/raw/awsconfiguration.json
@@ -1,0 +1,45 @@
+{
+  "IdentityManager": {
+    "Default": {}
+  },
+  "CredentialsProvider": {
+    "CognitoIdentity": {
+      "Default": {
+        "PoolId": "us-east-1:4bff454a-36de-4e9e-a789-60e7ad0f17a1",
+        "Region": "us-east-1"
+      }
+    }
+  },
+  "CognitoUserPool": {
+    "Default": {
+      "PoolId": "us-east-1_fHRx057zU",
+      "AppClientId": "tcb9gp2iebvj6fsffau3qqd0o",
+      "Region": "us-east-1"
+    }
+  },
+  "Auth": {
+    "Default": {
+      "OAuth": {
+        "WebDomain": "celltrak-practitioner-v3-dev.auth.us-east-1.amazoncognito.com",
+        "AppClientId": "tcb9gp2iebvj6fsffau3qqd0o",
+        "SignInRedirectURI": "celltraksd://celltraksd.ctt.com/authmain",
+        "SignOutRedirectURI": "celltraksd://celltraksd.ctt.com/authmain",
+        "Scopes": ["openid", "email", "profile", "aws.cognito.signin.user.admin"]
+      }
+    }
+  },
+  "AppSync": {
+    "Default": {
+      "ApiUrl": "https://pqbufswr7rdgrprrtysz24mtue.appsync-api.us-east-1.amazonaws.com/graphql",
+      "Region": "us-east-1",
+      "AuthMode": "AMAZON_COGNITO_USER_POOLS",
+      "ClientDatabasePrefix": "self-directed-appsync-dev_AMAZON_COGNITO_USER_POOLS"
+    }
+  },
+  "S3TransferUtility": {
+    "Default": {
+      "Bucket": "celltrak-self-directed-promo2-dev",
+      "Region": "us-east-1"
+    }
+  }
+}

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
   - amazon_s3_cognito (0.2.4):
-    - AWSCognitoIdentityProvider
-    - AWSCore
-    - AWSS3 (~> 2.19.1)
+    - AWSCognitoIdentityProvider (>= 2.22.2)
+    - AWSCore (>= 2.22.2)
+    - AWSS3 (>= 2.22.2)
     - Flutter
-  - AWSCognitoIdentityProvider (2.19.1):
-    - AWSCognitoIdentityProviderASF (= 2.19.1)
-    - AWSCore (= 2.19.1)
-  - AWSCognitoIdentityProviderASF (2.19.1)
-  - AWSCore (2.19.1)
-  - AWSS3 (2.19.1):
-    - AWSCore (= 2.19.1)
+  - AWSCognitoIdentityProvider (2.22.2):
+    - AWSCognitoIdentityProviderASF (= 2.22.2)
+    - AWSCore (= 2.22.2)
+  - AWSCognitoIdentityProviderASF (2.22.2)
+  - AWSCore (2.22.2)
+  - AWSS3 (2.22.2):
+    - AWSCore (= 2.22.2)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
@@ -31,11 +31,11 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  amazon_s3_cognito: cdf226462780131cd6fe82e202477b2625c6ba97
-  AWSCognitoIdentityProvider: e6932c709d3e0b234128aeb5f2052c9bf1032d8d
-  AWSCognitoIdentityProviderASF: 749f58b75e69f7f0144b9d38539525562b843d34
-  AWSCore: 55c154ae27efc5c98bdc30a0eeea5a35d10a2ab5
-  AWSS3: 2272253b098d07803af8dd20ce6ce7302bcffb47
+  amazon_s3_cognito: 23c7e1946953cb8b25dea08f322e3efdbd9a3ed9
+  AWSCognitoIdentityProvider: 89fd21fdfc22a33ff86520d2905eac9201a55b69
+  AWSCognitoIdentityProviderASF: a5c421ef17e27c226e4d780a24ac3af675cbf57a
+  AWSCore: df612cf038f1230dfae4695feb8497c512f1143a
+  AWSS3: 0d9d77caca819d7289e05ac5bf161943094ab2fa
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
 
 PODFILE CHECKSUM: c34e2287a9ccaa606aeceab922830efb9a6ff69a

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,15 +2,15 @@ PODS:
   - amazon_s3_cognito (0.2.4):
     - AWSCognitoIdentityProvider
     - AWSCore
-    - AWSS3
+    - AWSS3 (~> 2.19.1)
     - Flutter
-  - AWSCognitoIdentityProvider (2.12.2):
-    - AWSCognitoIdentityProviderASF (= 1.0.1)
-    - AWSCore (= 2.12.2)
-  - AWSCognitoIdentityProviderASF (1.0.1)
-  - AWSCore (2.12.2)
-  - AWSS3 (2.12.2):
-    - AWSCore (= 2.12.2)
+  - AWSCognitoIdentityProvider (2.19.1):
+    - AWSCognitoIdentityProviderASF (= 2.19.1)
+    - AWSCore (= 2.19.1)
+  - AWSCognitoIdentityProviderASF (2.19.1)
+  - AWSCore (2.19.1)
+  - AWSS3 (2.19.1):
+    - AWSCore (= 2.19.1)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
@@ -21,7 +21,6 @@ SPEC REPOS:
   https://cdn.cocoapods.org/:
     - AWSCognitoIdentityProvider
     - AWSCognitoIdentityProviderASF
-  https://github.com/CocoaPods/Specs.git:
     - AWSCore
     - AWSS3
 
@@ -32,13 +31,13 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  amazon_s3_cognito: 123d7b891d8a06991d5773f0f2f996b1888ef436
-  AWSCognitoIdentityProvider: 5ac7b7af7877e7a47585c08d6a0ef58bcd6314b6
-  AWSCognitoIdentityProviderASF: f94f1a502e72ef3d0a1de93e10bf7a79c8698118
-  AWSCore: bdc0933bcb1aca4a9af3352a9e6ec75b339faf71
-  AWSS3: 3ab1e1b25d3522d7745efd2a57a98a86d7524bd5
+  amazon_s3_cognito: cdf226462780131cd6fe82e202477b2625c6ba97
+  AWSCognitoIdentityProvider: e6932c709d3e0b234128aeb5f2052c9bf1032d8d
+  AWSCognitoIdentityProviderASF: 749f58b75e69f7f0144b9d38539525562b843d34
+  AWSCore: 55c154ae27efc5c98bdc30a0eeea5a35d10a2ab5
+  AWSS3: 2272253b098d07803af8dd20ce6ce7302bcffb47
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
 
 PODFILE CHECKSUM: c34e2287a9ccaa606aeceab922830efb9a6ff69a
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		EAAFF43A25CF33DB0005EF2A /* awsconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = EAAFF43925CF33DB0005EF2A /* awsconfiguration.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -47,6 +48,7 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9A486D573964F273AA99393B /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		9BAFBBE3DEB26B4BEF790D48 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EAAFF43925CF33DB0005EF2A /* awsconfiguration.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = awsconfiguration.json; path = ../../android/app/src/main/res/raw/awsconfiguration.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +104,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				EAAFF43925CF33DB0005EF2A /* awsconfiguration.json */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -196,6 +199,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EAAFF43A25CF33DB0005EF2A /* awsconfiguration.json in Resources */,
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,

--- a/ios/Classes/SwiftAmazonS3CognitoPlugin.swift
+++ b/ios/Classes/SwiftAmazonS3CognitoPlugin.swift
@@ -6,6 +6,8 @@ import AWSCognitoIdentityProvider
 
 public class SwiftAmazonS3CognitoPlugin: NSObject, FlutterPlugin {
 
+    var awsServiceConfiguration: AWSServiceConfiguration?
+    var s3TransferUtility: AWSS3TransferUtility?
     var s3BucketName: String?
     var s3RegionName: String?
     var s3Region: AWSRegionType?
@@ -19,22 +21,38 @@ public class SwiftAmazonS3CognitoPlugin: NSObject, FlutterPlugin {
     var idPoolRegionName: String?
     var idPoolRegion: AWSRegionType?
 
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "amazon_s3_cognito", binaryMessenger: registrar.messenger())
-    let instance = SwiftAmazonS3CognitoPlugin()
-    registrar.addMethodCallDelegate(instance, channel: channel)
-  }
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let channel = FlutterMethodChannel(name: "amazon_s3_cognito", binaryMessenger: registrar.messenger())
+        let instance = SwiftAmazonS3CognitoPlugin()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
 
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-          initConfig()
-          if (call.method.elementsEqual("uploadImage")) {
-              uploadImageForRegion(call,result: result)
-          } else if (call.method.elementsEqual("downloadImage")) {
-              downloadImageForRegion(call,result: result)
-          } else if (call.method.elementsEqual("deleteImage")) {
-              deleteImage(call,result: result)
-          }
-      }
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        initialize()
+        if (call.method.elementsEqual("uploadImage")) {
+            uploadImage(call,result: result)
+        } else if (call.method.elementsEqual("downloadImage")) {
+            downloadImage(call,result: result)
+        } else if (call.method.elementsEqual("deleteImage")) {
+            deleteImage(call,result: result)
+        }
+    }
+
+    func initialize() {
+        initConfig()
+
+        // reference: https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-integrating-user-pools-with-identity-pools.html
+        let serviceConfiguration = AWSServiceConfiguration(region: s3Region!, credentialsProvider: nil)
+        let userPoolConfiguration = AWSCognitoIdentityUserPoolConfiguration(clientId: userPoolAppClientId!, clientSecret: nil, poolId: userPoolId!)
+        AWSCognitoIdentityUserPool.register(with: serviceConfiguration, userPoolConfiguration: userPoolConfiguration, forKey: "UserPool")
+
+        let pool = AWSCognitoIdentityUserPool(forKey: "UserPool")
+        let credentialsProvider = AWSCognitoCredentialsProvider(regionType: idPoolRegion!, identityPoolId: idPoolId!, identityProviderManager:pool)
+        awsServiceConfiguration = AWSServiceConfiguration(region: userPoolRegion!, credentialsProvider: credentialsProvider)
+        AWSServiceManager.default().defaultServiceConfiguration = awsServiceConfiguration
+
+        s3TransferUtility = AWSS3TransferUtility.default()
+    }
 
     /// reads config from awsconfiguration.json in Runner/config/<env>/,
     /// where <env> is one of dev, qa, uat, or prod.
@@ -60,180 +78,152 @@ public class SwiftAmazonS3CognitoPlugin: NSObject, FlutterPlugin {
         idPoolRegion = getRegion(name: idPoolRegionName!)
     }
 
-    public func nameGenerator() -> String{
-          let date = Date()
-          let formatter = DateFormatter()
-          formatter.dateFormat = "ddMMyyyy"
-          let result = formatter.string(from: date)
-          return "IMG" + result + String(Int64(date.timeIntervalSince1970 * 1000)) + "jpeg"
-      }
+    public func nameGenerator() -> String {
+        let date = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "ddMMyyyy"
+        let result = formatter.string(from: date)
+        return "IMG" + result + String(Int64(date.timeIntervalSince1970 * 1000)) + "jpeg"
+    }
 
-      func uploadImageForRegion(_ call: FlutterMethodCall, result: @escaping FlutterResult){
-          let arguments = call.arguments as? NSDictionary
-          let imagePath = arguments!["filePath"] as? String
-          let fileName = arguments!["imageName"] as? String
-          let contentTypeParam = arguments!["contentType"] as? String
+    func uploadImage(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let arguments = call.arguments as? NSDictionary
+        let imagePath = arguments!["filePath"] as? String
+        let fileName = arguments!["imageName"] as? String
+        let contentTypeParam = arguments!["contentType"] as? String
 
-          var imageAmazonUrl = ""
-          let fileUrl = NSURL(fileURLWithPath: imagePath!)
+        var imageAmazonUrl = ""
+        let fileUrl = NSURL(fileURLWithPath: imagePath!)
 
         var contentType = "image/jpeg"
-        if(contentTypeParam != nil &&
-            contentTypeParam!.count > 0){
+        if (contentTypeParam != nil && contentTypeParam!.count > 0) {
             contentType = contentTypeParam!
         }
 
-        if(contentTypeParam == nil || contentTypeParam!.count == 0 &&  fileName!.contains(".")){
-                       var index = fileName!.lastIndex(of: ".")
-                       index = fileName!.index(index!, offsetBy: 1)
-                       if(index != nil){
-                           let extention = String(fileName![index!...])
-                           print("extension"+extention);
-                           if(extention.lowercased().contains("png") ||
-                           extention.lowercased().contains("jpg") ||
-                               extention.lowercased().contains("jpeg") ){
-                               contentType = "image/"+extention
-                           }else{
-
-                            if(extention.lowercased().contains("pdf")){
-                                contentType = "application/pdf"
-                                }else{
-                                contentType = "application/*"
-                                }
-                           }
-                       }
-                   }
-
-          // reference: https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-integrating-user-pools-with-identity-pools.html
-          let serviceConfiguration = AWSServiceConfiguration(region: s3Region!, credentialsProvider: nil)
-          let userPoolConfiguration = AWSCognitoIdentityUserPoolConfiguration(clientId: userPoolAppClientId!, clientSecret: nil, poolId: userPoolId!)
-          AWSCognitoIdentityUserPool.register(with: serviceConfiguration, userPoolConfiguration: userPoolConfiguration, forKey: "UserPool")
-
-          let pool = AWSCognitoIdentityUserPool(forKey: "UserPool")
-          let credentialsProvider = AWSCognitoCredentialsProvider(regionType: idPoolRegion!, identityPoolId: idPoolId!, identityProviderManager:pool)
-          let configuration = AWSServiceConfiguration(region: userPoolRegion!, credentialsProvider: credentialsProvider)
-          AWSServiceManager.default().defaultServiceConfiguration = configuration
-
-          let uploadRequest = AWSS3TransferManagerUploadRequest()
-          uploadRequest?.bucket = s3BucketName
-          uploadRequest?.key = fileName
-          uploadRequest?.contentType = contentType
-          uploadRequest?.body = fileUrl as URL
-
-          AWSS3TransferManager.default().upload(uploadRequest!).continueWith { (task) -> AnyObject? in
-              if let error = task.error {
-                  print("❌ Upload failed: (\(error))")
-              }
-
-              if task.result != nil {
-                imageAmazonUrl = "https://s3-\(self.s3RegionName!).amazonaws.com/\(self.s3BucketName!)/\(uploadRequest!.key!)"
-                  print("✅ Upload complete: (\(imageAmazonUrl))")
-              } else {
-                  print("❌ Unexpected empty result.")
-              }
-              result(imageAmazonUrl)
-              return nil
-          }
-      }
-
-      func downloadImageForRegion(_ call: FlutterMethodCall, result: @escaping FlutterResult){
-                let arguments = call.arguments as? NSDictionary
-                let imagePath = arguments!["filePath"] as? String
-                let fileName = arguments!["imageName"] as? String
-
-                var imageAmazonUrl = ""
-                let fileUrl = NSURL(fileURLWithPath: imagePath!)
-
-                let uploadRequest = AWSS3TransferManagerDownloadRequest()
-                uploadRequest?.bucket = s3BucketName
-                uploadRequest?.key = fileName
-                uploadRequest?.downloadingFileURL = fileUrl as URL
-
-                let credentialsProvider = AWSCognitoCredentialsProvider(regionType: idPoolRegion!, identityPoolId: idPoolId!)
-                let configuration = AWSServiceConfiguration(region: userPoolRegion!, credentialsProvider: credentialsProvider)
-                AWSServiceManager.default().defaultServiceConfiguration = configuration
-
-                AWSS3TransferManager.default().download(uploadRequest!).continueWith { (task) -> AnyObject? in
-                    if let error = task.error {
-                        print("❌ Download failed (\(error))")
-                    }
-
-                    if task.result != nil {
-                        imageAmazonUrl = imagePath!
-                        print("✅ Download successed (\(imageAmazonUrl))")
+        if (contentTypeParam == nil || contentTypeParam!.count == 0 && fileName!.contains(".")) {
+            var index = fileName!.lastIndex(of: ".")
+            index = fileName!.index(index!, offsetBy: 1)
+            if (index != nil) {
+                let extension1 = String(fileName![index!...])
+                print("extension" + extension1);
+                if (extension1.lowercased().contains("png") ||
+                    extension1.lowercased().contains("jpg") ||
+                    extension1.lowercased().contains("jpeg")) {
+                    contentType = "image/" + extension1
+                } else {
+                    if (extension1.lowercased().contains("pdf")) {
+                        contentType = "application/pdf"
                     } else {
-                        print("❌ Unexpected empty result.")
+                        contentType = "application/*"
                     }
-                    result(imageAmazonUrl)
-                    return nil
                 }
             }
+        }
 
-      func deleteImage(_ call: FlutterMethodCall, result: @escaping FlutterResult){
-          let arguments = call.arguments as? NSDictionary
-          let fileName = arguments!["imageName"] as? String
+        s3TransferUtility?.uploadFile(fileUrl as URL, bucket: s3BucketName!, key: fileName!, contentType: contentType, expression: nil, completionHandler: nil).continueWith {
+            (task) -> AnyObject? in if let error = task.error {
+                print("❌ Upload failed: (\(error))")
+            }
 
-          let credentialsProvider = AWSCognitoCredentialsProvider(regionType: idPoolRegion!, identityPoolId: idPoolId!)
-          let configuration = AWSServiceConfiguration(region: userPoolRegion!, credentialsProvider: credentialsProvider)
-          AWSServiceManager.default().defaultServiceConfiguration = configuration
+            if (task.result != nil) {
+                imageAmazonUrl = "https://\(self.s3BucketName!).s3.amazonaws.com/\(fileName!)"
+                print("✅ Upload complete: (\(imageAmazonUrl))")
+            } else {
+                print("❌ Unexpected empty result.")
+            }
 
-          AWSS3.register(with: configuration!, forKey: "defaultKey")
-          let s3 = AWSS3.s3(forKey: "defaultKey")
-          let deleteObjectRequest = AWSS3DeleteObjectRequest()
-          deleteObjectRequest?.bucket = s3BucketName
-          deleteObjectRequest?.key = fileName
-          s3.deleteObject(deleteObjectRequest!).continueWith { (task:AWSTask) -> AnyObject? in
-              if let error = task.error {
-                  print("Error occurred: \(error)")
-                  result("Error occurred: \(error)")
-                  return nil
-              }
-              print("image deleted successfully.")
-              result("image deleted successfully.")
-              return nil
-          }
-      }
+            result(imageAmazonUrl)
+            return nil
+        }
+    }
 
-      public func getRegion( name:String ) -> AWSRegionType{
-          if (name == "US-EAST-1"){
-              return AWSRegionType.USEast1
-          } else if(name == "AP-SOUTHEAST-1"){
-              return AWSRegionType.APSoutheast1
-          } else if(name == "US-EAST-2"){
-              return AWSRegionType.USEast2
-          } else if(name == "EU-WEST-1"){
-              return AWSRegionType.EUWest1
-          } else if(name == "CA-CENTRAL-1"){
-              return AWSRegionType.CACentral1
-          } else if(name == "CN-NORTH-1"){
-              return AWSRegionType.CNNorth1
-          } else if(name == "CN-NORTHWEST-1"){
-              return AWSRegionType.CNNorthWest1
-          } else if(name == "EU-CENTRAL-1"){
-              return AWSRegionType.EUCentral1
-          } else if(name == "EU-WEST-2"){
-              return AWSRegionType.EUWest2
-          } else if(name == "EU-WEST-3"){
-              return AWSRegionType.EUWest3
-          } else if(name == "SA-EAST-1"){
-              return AWSRegionType.SAEast1
-          } else if(name == "US-WEST-1"){
-              return AWSRegionType.USWest1
-          } else if(name == "US-WEST-2"){
-              return AWSRegionType.USWest2
-          } else if(name == "AP-NORTHEAST-1"){
-              return AWSRegionType.APNortheast1
-          } else if(name == "AP-NORTHEAST-2"){
-              return AWSRegionType.APNortheast2
-          } else if(name == "AP-SOUTHEAST-1"){
-              return AWSRegionType.APSoutheast1
-          } else if(name == "AP-SOUTHEAST-2"){
-              return AWSRegionType.APSoutheast2
-          } else if(name == "AP-SOUTH-1"){
-              return AWSRegionType.APSouth1
-          } else if(name == "ME-SOUTH-1"){
+    func downloadImage(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let arguments = call.arguments as? NSDictionary
+        let imagePath = arguments!["filePath"] as? String
+        let fileName = arguments!["imageName"] as? String
+
+        var resultUrl = ""
+        let fileUrl = NSURL(fileURLWithPath: imagePath!)
+
+        s3TransferUtility?.download(to: fileUrl as URL, bucket: s3BucketName!, key: fileName!, expression: nil, completionHandler: nil).continueWith {
+            (task) -> AnyObject? in if let error = task.error {
+                print("❌ Download failed: (\(error))")
+            }
+
+            if (task.result != nil) {
+                resultUrl = imagePath!
+                print("✅ Download complete: (\(resultUrl))")
+            } else {
+                print("❌ Unexpected empty result.")
+            }
+
+            result(resultUrl)
+            return nil
+        }
+    }
+
+    func deleteImage(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let arguments = call.arguments as? NSDictionary
+        let fileName = arguments!["imageName"] as? String
+
+        AWSS3.register(with: awsServiceConfiguration!, forKey: "defaultKey")
+        let s3 = AWSS3.s3(forKey: "defaultKey")
+        let deleteObjectRequest = AWSS3DeleteObjectRequest()
+        deleteObjectRequest?.bucket = s3BucketName
+        deleteObjectRequest?.key = fileName
+        s3.deleteObject(deleteObjectRequest!).continueWith {
+            (task:AWSTask) -> AnyObject? in if let error = task.error {
+                print("Error occurred in deleteImage: \(error)")
+                result("Error occurred: \(error)")
+                return nil
+            }
+
+            print("image deleted successfully.")
+            result("image deleted successfully.")
+            return nil
+        }
+    }
+
+    func getRegion( name:String ) -> AWSRegionType {
+        if (name == "US-EAST-1") {
+            return AWSRegionType.USEast1
+        } else if(name == "AP-SOUTHEAST-1") {
+            return AWSRegionType.APSoutheast1
+        } else if(name == "US-EAST-2") {
+            return AWSRegionType.USEast2
+        } else if(name == "EU-WEST-1") {
+            return AWSRegionType.EUWest1
+        } else if(name == "CA-CENTRAL-1") {
+            return AWSRegionType.CACentral1
+        } else if(name == "CN-NORTH-1") {
+            return AWSRegionType.CNNorth1
+        } else if(name == "CN-NORTHWEST-1") {
+            return AWSRegionType.CNNorthWest1
+        } else if(name == "EU-CENTRAL-1") {
+            return AWSRegionType.EUCentral1
+        } else if(name == "EU-WEST-2") {
+            return AWSRegionType.EUWest2
+        } else if(name == "EU-WEST-3") {
+            return AWSRegionType.EUWest3
+        } else if(name == "SA-EAST-1") {
+            return AWSRegionType.SAEast1
+        } else if(name == "US-WEST-1") {
+            return AWSRegionType.USWest1
+        } else if(name == "US-WEST-2") {
+            return AWSRegionType.USWest2
+        } else if(name == "AP-NORTHEAST-1")  {
+            return AWSRegionType.APNortheast1
+        } else if(name == "AP-NORTHEAST-2"){
+            return AWSRegionType.APNortheast2
+        } else if(name == "AP-SOUTHEAST-1") {
+            return AWSRegionType.APSoutheast1
+        } else if(name == "AP-SOUTHEAST-2") {
+            return AWSRegionType.APSoutheast2
+        } else if(name == "AP-SOUTH-1") {
+            return AWSRegionType.APSouth1
+        } else if(name == "ME-SOUTH-1") {
             return AWSRegionType.MESouth1
-          }
-          return AWSRegionType.Unknown
-      }
+        }
+        return AWSRegionType.Unknown
+    }
 }

--- a/ios/amazon_s3_cognito.podspec
+++ b/ios/amazon_s3_cognito.podspec
@@ -15,9 +15,9 @@ This plugin allows users to upload and delete image for amazon s3 cognito
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AWSS3', '~> 2.19.1'
-  s.dependency 'AWSCore'
-  s.dependency 'AWSCognitoIdentityProvider'
+  s.dependency 'AWSS3', '>= 2.22.2'
+  s.dependency 'AWSCore', '>= 2.22.2'
+  s.dependency 'AWSCognitoIdentityProvider', '>= 2.22.2'
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '11.0'
 end

--- a/ios/amazon_s3_cognito.podspec
+++ b/ios/amazon_s3_cognito.podspec
@@ -15,7 +15,7 @@ This plugin allows users to upload and delete image for amazon s3 cognito
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AWSS3'
+  s.dependency 'AWSS3', '~> 2.19.1'
   s.dependency 'AWSCore'
   s.dependency 'AWSCognitoIdentityProvider'
 


### PR DESCRIPTION
This PR migrates from the AWSS3TransferManager to AWSS3TransferUtility. This was needed as AWS completely removed the old class in its recent releases of the SDK, and we need the most recent release to pull in the iOS hosted UI updates.

There are also a bunch of spacing/formatting updates, sorry about that. The important changes are pretty small.

There is also a small related change in AppDelegate, and it will come with the next flutter_celltrak_sd update. Here is the original explanation and migration helps from AWS: https://aws.amazon.com/blogs/mobile/amazon-s3-transfer-utility-for-ios/